### PR TITLE
feat: add endpoint to list available ML models

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -9,6 +9,7 @@ from app import models
 from app.database import engine
 from app.clients.router import router as clients_router
 from app.auth.router import router as auth_router
+from app.modelmgmt.router import router as model_router
 from fastapi.middleware.cors import CORSMiddleware
 
 # Initialize database tables
@@ -24,6 +25,7 @@ app = FastAPI(
 # Include routers
 app.include_router(auth_router)
 app.include_router(clients_router)
+app.include_router(model_router)
 
 # Configure CORS middleware
 app.add_middleware(

--- a/app/modelmgmt/model_list.py
+++ b/app/modelmgmt/model_list.py
@@ -1,0 +1,13 @@
+"""
+Model listing module for the Common Assessment Tool.
+
+Provides a list of available machine learning models
+that can be selected or switched to by the backend.
+Currently uses a static list for demonstration purposes.
+"""
+
+def list_models():
+    """
+    Return a list of available mock models.
+    """
+    return ["random_forest", "svm", "xgboost"]

--- a/app/modelmgmt/model_list.py
+++ b/app/modelmgmt/model_list.py
@@ -1,13 +1,13 @@
 """
 Model listing module for the Common Assessment Tool.
-
 Provides a list of available machine learning models
 that can be selected or switched to by the backend.
 Currently uses a static list for demonstration purposes.
 """
 
-def list_models():
+def get_available_models():
     """
     Return a list of available mock models.
     """
     return ["random_forest", "svm", "xgboost"]
+

--- a/app/modelmgmt/router.py
+++ b/app/modelmgmt/router.py
@@ -4,5 +4,6 @@ from app.modelmgmt.model_list import get_available_models
 router = APIRouter(prefix="/models", tags=["models"])
 
 @router.get("/", summary="List available ML models")
-def list_models():
+def list_models_route():
     return {"available_models": get_available_models()}
+

--- a/app/modelmgmt/router.py
+++ b/app/modelmgmt/router.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+from app.modelmgmt.model_list import get_available_models
+
+router = APIRouter(prefix="/models", tags=["models"])
+
+@router.get("/", summary="List available ML models")
+def list_models():
+    return {"available_models": get_available_models()}


### PR DESCRIPTION
### Summary

Added a new API endpoint to list available machine learning models.  
Currently returns a static mock list as the initial step for Story 2.

### Changes

- Created `modelmgmt` module with `model_list.py`
- Added `/models` endpoint under `modelmgmt/router.py`
- Hooked up new router in `main.py`

### Related Issue

Closes #11