### PR TITLE
feat: add API to get current ML model

### DIFF
--- a/app/modelmgmt/model_list.py
+++ b/app/modelmgmt/model_list.py
@@ -1,13 +1,27 @@
 """
-Model listing module for the Common Assessment Tool.
-Provides a list of available machine learning models
-that can be selected or switched to by the backend.
-Currently uses a static list for demonstration purposes.
+Model listing and selection module for the Common Assessment Tool.
+
+Provides:
+- A list of available machine learning models
+- Logic to get the currently active model (mock)
+- Support for switching models (to be implemented)
+
+Currently uses a static list and a mock current model for demonstration purposes.
 """
+
+AVAILABLE_MODELS = ["random_forest", "svm", "xgboost"]
+CURRENT_MODEL = "random_forest"
 
 def get_available_models():
     """
     Return a list of available mock models.
     """
-    return ["random_forest", "svm", "xgboost"]
+    return AVAILABLE_MODELS
+
+def get_current_model():
+    """
+    Return the currently active model (mock).
+    """
+    return CURRENT_MODEL
+
 

--- a/app/modelmgmt/router.py
+++ b/app/modelmgmt/router.py
@@ -1,9 +1,13 @@
 from fastapi import APIRouter
-from app.modelmgmt.model_list import get_available_models
+from app.modelmgmt.model_list import get_available_models, get_current_model
 
 router = APIRouter(prefix="/models", tags=["models"])
 
 @router.get("/", summary="List available ML models")
 def list_models_route():
     return {"available_models": get_available_models()}
+
+@router.get("/current", summary="Get current ML model")
+def current_model():
+    return {"current_model": get_current_model()}
 


### PR DESCRIPTION
Added a new API endpoint to retrieve the currently selected machine learning model.
This is the second step for Story 2 and currently returns a mock model name.

Closes #13 