### PR TITLE
feat: add switch model API

### DIFF
--- a/app/modelmgmt/model_list.py
+++ b/app/modelmgmt/model_list.py
@@ -24,4 +24,20 @@ def get_current_model():
     """
     return CURRENT_MODEL
 
+def switch_model(new_model: str):
+    """
+    Switch the current model to a new one if it's available.
+
+    Args:
+        new_model (str): The name of the model to switch to
+
+    Raises:
+        ValueError: If the model is not in the available list
+    """
+    global CURRENT_MODEL
+    if new_model not in AVAILABLE_MODELS:
+        raise ValueError(f"Model '{new_model}' is not in the available list.")
+    CURRENT_MODEL = new_model
+
+
 

--- a/app/modelmgmt/router.py
+++ b/app/modelmgmt/router.py
@@ -1,13 +1,33 @@
-from fastapi import APIRouter
-from app.modelmgmt.model_list import get_available_models, get_current_model
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from app.modelmgmt.model_list import (
+    get_available_models,
+    get_current_model,
+    switch_model,
+)
 
 router = APIRouter(prefix="/models", tags=["models"])
+
+
+class ModelSwitchRequest(BaseModel):
+    model: str
+
 
 @router.get("/", summary="List available ML models")
 def list_models_route():
     return {"available_models": get_available_models()}
 
+
 @router.get("/current", summary="Get current ML model")
 def current_model():
     return {"current_model": get_current_model()}
 
+
+@router.post("/switch", summary="Switch current ML model")
+def switch_model_route(request: ModelSwitchRequest):
+    try:
+        switch_model(request.model)
+        return {"message": f"Model switched to {request.model}"}
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))


### PR DESCRIPTION
Added a new API endpoint to switch the current machine learning model.

This is the 3rd step in Story 2. The switching logic is currently mock-based using a static model list.

Closes #17

